### PR TITLE
Fix check_for_win to properly detect player_two win

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -30,30 +30,24 @@ class Board
 
   # Currently only places "X" pieces; will add additional piece variants alongside player class
   def play_piece(column_selection, human)
-    if column_selection < 1 || column_selection > @columns
-      "Error: Selected column does not exist."
-    elsif @board_matrix.column(column_selection - 1)[0] != "\u{25cc}"
-      "Error: Column is already full."
-    else
-      column_index = 0
-      @board_matrix.column(column_selection - 1).each do |cell|
-        if cell == "\u{25cc}" && column_index < @rows
-          column_index += 1
-        end
+    column_index = 0
+    @board_matrix.column(column_selection - 1).each do |cell|
+      if cell == "\u{25cc}" && column_index < @rows
+        column_index += 1
       end
-      if human 
-        @board_matrix[column_index - 1, column_selection - 1] = "X"
-      else
-        @board_matrix[column_index - 1, column_selection - 1] = "O"
-      end
-      @played_piece = [column_index - 1, column_selection - 1] # Assigning last played piece coords to variable for check_for_win
     end
+    if human 
+      @board_matrix[column_index - 1, column_selection - 1] = "X"
+    else
+      @board_matrix[column_index - 1, column_selection - 1] = "O"
+    end
+    @played_piece = [column_index - 1, column_selection - 1] # Assigning last played piece coords to variable for check_for_win
   end
 
   def check_for_win
     # Use the row coordinates from @played_piece to identify row, then convert row to array, then check array with each_cons
     @board_matrix.row(@played_piece[0]).to_a.each_cons(4) do |cells| 
-      if cells == ["X", "X", "X", "X"]
+      if cells == ["X", "X", "X", "X"] || cells == ["O", "O", "O", "O"]
         display_board
         puts "Horizontal Win!"
         return true
@@ -61,7 +55,7 @@ class Board
     end
     # Use the column coordinates from @played_piece to identify column, then convert column to array, then check array with each_cons
     @board_matrix.column(@played_piece[1]).to_a.each_cons(4) do |cells|
-      if cells == ["X", "X", "X", "X"]
+      if cells == ["X", "X", "X", "X"] || cells == ["O", "O", "O", "O"]
         display_board
         puts "Vertical Win!"
         return true
@@ -78,7 +72,7 @@ class Board
       @board_matrix[@played_piece[0]+3,@played_piece[1]+3],
     ]
     diagonal_array_up_left.each_cons(4) do |cells|
-      if cells == ["X", "X", "X", "X"]
+      if cells == ["X", "X", "X", "X"] || cells == ["O", "O", "O", "O"]
         display_board
         puts "Diagonal Win! (Up Left)"
         return true
@@ -95,7 +89,7 @@ class Board
       @board_matrix[@played_piece[0]+3,@played_piece[1]-3],
     ]
     diagonal_array_up_right.each_cons(4) do |cells|
-      if cells == ["X", "X", "X", "X"]
+      if cells == ["X", "X", "X", "X"] || cells == ["O", "O", "O", "O"]
         display_board
         puts "Diagonal Win! (Up Right)"
         return true

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -44,10 +44,8 @@ class Game
 
   def valid_input(user_input)
     if user_input.to_i < 1 || user_input.to_i > @board.columns # ensures the input matches one of the columns
-      puts "Error: Selected column does not exist."
       return "error_nocolumn"
     elsif @board.board_matrix.column(user_input.to_i - 1)[0] != "\u{25cc}" # ensures the column is not already full
-      puts "Error: Column is already full."
       return "error_fullcolumn"
     else
       return "valid"
@@ -60,9 +58,9 @@ class Game
       puts "Please select a column by entering its number."
       while user_input = gets.chomp # input loop for player column selection
         if valid_input(user_input) == "error_nocolumn"
-          puts "Error: Selected column does not exist."
+          puts "Error: Selected column does not exist. Please select a valid column."
         elsif valid_input(user_input) == "error_fullcolumn"
-          puts "Error: Column is already full."
+          puts "Error: Column is already full. Please select a valid column."
         else
           @board.play_piece(user_input.to_i, player_one.human?) # plays the piece, and breaks the loop
           break


### PR DESCRIPTION
We realized after the deadline that we forgot to modify our check_for_win method to properly account for player_two's pieces. :\ (The piece differentiation between player_one and player_two was one of our last implemented features.) Also, there was redundant/duplicate error messaging when the player or computer selected an invalid column.

Leaving this pull request open and unmerged, as we want to clarify this fix came in after the deadline passed.